### PR TITLE
Improve grid snapping and map selection tools

### DIFF
--- a/gridapp.py
+++ b/gridapp.py
@@ -50,8 +50,11 @@ from PySide6.QtWidgets import (
     QListWidget,
     QListWidgetItem,
     QMainWindow,
+    QMessageBox,
     QSpinBox,
+    QTabWidget,
     QToolBar,
+    QToolButton,
 )
 
 
@@ -71,12 +74,14 @@ class ObjectSpec:
     fill: QColor = field(default_factory=lambda: QColor(Qt.lightGray))
 
 
-PALETTE: list[ObjectSpec] = [
-    ObjectSpec("Base", 3, 3, QColor(Qt.lightGray)),
-    ObjectSpec("Outpost", 2, 2, QColor(Qt.cyan)),
-    ObjectSpec("Resource", 2, 1, QColor(Qt.yellow)),
-    ObjectSpec("Relay", 1, 1, QColor(Qt.green)),
-]
+DEFAULT_CATEGORIES: dict[str, list[ObjectSpec]] = {
+    "Alliance": [
+        ObjectSpec("Base", 3, 3, QColor(Qt.lightGray)),
+        ObjectSpec("Outpost", 2, 2, QColor(Qt.cyan)),
+        ObjectSpec("Resource", 2, 1, QColor(Qt.yellow)),
+        ObjectSpec("Relay", 1, 1, QColor(Qt.green)),
+    ]
+}
 
 
 # ----------------------------- Map Items -------------------------------
@@ -133,19 +138,20 @@ class MapObject(QGraphicsItemGroup):
 
     def mouseReleaseEvent(self, event):
         super().mouseReleaseEvent(event)
-        # Snap object's CENTER to the nearest cell center on release
+        scene = self.scene()
+        if scene is None:
+            return
         cs = self.cell_size
         w = self.spec.size_w * cs
         h = self.spec.size_h * cs
-        center_x = self.pos().x() + w / 2
-        center_y = self.pos().y() + h / 2
-        i = round(center_x / cs - 0.5)
-        j = round(center_y / cs - 0.5)
-        snapped_center_x = (i + 0.5) * cs
-        snapped_center_y = (j + 0.5) * cs
-        new_x = snapped_center_x - w / 2
-        new_y = snapped_center_y - h / 2
-        self.setPos(QPointF(new_x, new_y))
+        current_top_left = self.pos()
+        snapped_x = round(current_top_left.x() / cs) * cs
+        snapped_y = round(current_top_left.y() / cs) * cs
+        if isinstance(scene, MapScene):
+            top_left = scene._clamp_top_left(snapped_x, snapped_y, w, h)
+        else:
+            top_left = QPointF(snapped_x, snapped_y)
+        self.setPos(top_left)
 
 
 class PreviewObject(QGraphicsItemGroup):
@@ -214,6 +220,11 @@ class MapScene(QGraphicsScene):
     def scene_height(self) -> float:
         return float(self.sceneRect().height())
 
+    def _clamp_top_left(self, x: float, y: float, w: float, h: float) -> QPointF:
+        x = max(0, min(self.scene_width() - w, x))
+        y = max(0, min(self.scene_height() - h, y))
+        return QPointF(x, y)
+
     def _top_left_from_center_snap(self, scene_pos: QPointF) -> QPointF:
         cs = self.cell_size
         spec = self.active_spec
@@ -221,17 +232,11 @@ class MapScene(QGraphicsScene):
             return QPointF(0, 0)
         w = spec.size_w * cs
         h = spec.size_h * cs
-        # snap center to (i+0.5)*cs close to cursor
-        i = round(scene_pos.x() / cs - 0.5)
-        j = round(scene_pos.y() / cs - 0.5)
-        snapped_center_x = (i + 0.5) * cs
-        snapped_center_y = (j + 0.5) * cs
-        x = snapped_center_x - w / 2
-        y = snapped_center_y - h / 2
-        # clamp inside scene
-        x = max(0, min(self.scene_width() - w, x))
-        y = max(0, min(self.scene_height() - h, y))
-        return QPointF(x, y)
+        desired_top_left_x = scene_pos.x() - w / 2
+        desired_top_left_y = scene_pos.y() - h / 2
+        snapped_x = round(desired_top_left_x / cs) * cs
+        snapped_y = round(desired_top_left_y / cs) * cs
+        return self._clamp_top_left(snapped_x, snapped_y, w, h)
 
     # --- Placement tool API ---
     def set_active_spec(self, spec: Optional[ObjectSpec]):
@@ -309,6 +314,12 @@ class MapView(QGraphicsView):
 
         self._panning = False
         self._pan_start = QPointF()
+        self._rubber_selecting = False
+
+    def _map_object_from_item(self, item: Optional[QGraphicsItem]) -> Optional[MapObject]:
+        while item is not None and not isinstance(item, MapObject):
+            item = item.parentItem()
+        return item if isinstance(item, MapObject) else None
 
     def wheelEvent(self, event):
         # Zoom on wheel: Ctrl for fine steps
@@ -344,8 +355,30 @@ class MapView(QGraphicsView):
                 event.accept()
                 return
         # Pan with Middle mouse or Shift + Left
+        item_under_cursor = None
+        if event.button() == Qt.LeftButton:
+            item_under_cursor = self._map_object_from_item(
+                self.itemAt(event.position().toPoint())
+            )
+        if (
+            event.button() == Qt.LeftButton
+            and (event.modifiers() & Qt.ShiftModifier)
+            and scene.active_spec is None
+            and item_under_cursor is not None
+        ):
+            item_under_cursor.setSelected(True)
+            event.accept()
+            return
+        if event.button() == Qt.LeftButton and scene.active_spec is None and not (
+            event.modifiers() & Qt.ShiftModifier
+        ):
+            if item_under_cursor is None:
+                self.setDragMode(QGraphicsView.RubberBandDrag)
+                self._rubber_selecting = True
         if event.button() == Qt.MiddleButton or (
-            event.button() == Qt.LeftButton and (event.modifiers() & Qt.ShiftModifier)
+            event.button() == Qt.LeftButton
+            and (event.modifiers() & Qt.ShiftModifier)
+            and (item_under_cursor is None or scene.active_spec is not None)
         ):
             self._panning = True
             p = event.position()
@@ -377,12 +410,31 @@ class MapView(QGraphicsView):
             event.accept()
             return
         super().mouseReleaseEvent(event)
+        if self._rubber_selecting and event.button() == Qt.LeftButton:
+            self.setDragMode(QGraphicsView.NoDrag)
+            self._rubber_selecting = False
+
+    def keyPressEvent(self, event):
+        if event.key() == Qt.Key_Delete:
+            scene: MapScene = self.scene()
+            to_remove: set[MapObject] = set()
+            for item in scene.selectedItems():
+                map_obj = self._map_object_from_item(item)
+                if map_obj is not None:
+                    to_remove.add(map_obj)
+            if to_remove:
+                for obj in to_remove:
+                    scene.removeItem(obj)
+                event.accept()
+                return
+        super().keyPressEvent(event)
 
 
 # ----------------------------- Sidebar --------------------------------
 class PaletteList(QListWidget):
-    def __init__(self, parent=None):
+    def __init__(self, specs: list[ObjectSpec], parent=None):
         super().__init__(parent)
+        self.specs = specs
         self.setAlternatingRowColors(True)
         self.populate()
         self.itemClicked.connect(self._on_item_clicked)
@@ -390,7 +442,7 @@ class PaletteList(QListWidget):
 
     def populate(self):
         self.clear()
-        for spec in PALETTE:
+        for spec in self.specs:
             item = QListWidgetItem(f"{spec.name}  ({spec.size_w}x{spec.size_h})")
             item.setData(Qt.UserRole, spec)
             self.addItem(item)
@@ -419,6 +471,62 @@ class PaletteList(QListWidget):
             w.refresh_active_preview_if(spec)
 
 
+# ---------------------------- Palette Tabs ----------------------------
+class PaletteTabWidget(QTabWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setMovable(True)
+        self.tabBarDoubleClicked.connect(self._rename_category)
+
+        add_btn = QToolButton(self)
+        add_btn.setText("+")
+        add_btn.clicked.connect(self._prompt_new_category)
+        self.setCornerWidget(add_btn, Qt.TopRightCorner)
+
+        for name, specs in DEFAULT_CATEGORIES.items():
+            self.add_category(name, specs)
+
+    def add_category(self, name: str, specs: Optional[list[ObjectSpec]] = None):
+        if specs is None:
+            specs = []
+        list_widget = PaletteList(specs, self)
+        self.addTab(list_widget, name)
+        return list_widget
+
+    def _prompt_new_category(self):
+        name, ok = QInputDialog.getText(self, "Add Category", "Category name:")
+        if not ok:
+            return
+        name = name.strip()
+        if not name:
+            return
+        if self._category_exists(name):
+            QMessageBox.information(self, "Category exists", f"Category '{name}' already exists.")
+            return
+        self.add_category(name)
+
+    def _rename_category(self, index: int):
+        if index < 0:
+            return
+        current_name = self.tabText(index)
+        name, ok = QInputDialog.getText(self, "Rename Category", "Category name:", text=current_name)
+        if not ok:
+            return
+        name = name.strip()
+        if not name:
+            return
+        if name != current_name and self._category_exists(name):
+            QMessageBox.information(self, "Category exists", f"Category '{name}' already exists.")
+            return
+        self.setTabText(index, name)
+
+    def _category_exists(self, name: str) -> bool:
+        for i in range(self.count()):
+            if self.tabText(i).lower() == name.lower():
+                return True
+        return False
+
+
 # ----------------------------- Main Window -----------------------------
 class MainWindow(QMainWindow):
     def __init__(self):
@@ -432,9 +540,9 @@ class MainWindow(QMainWindow):
         self.setCentralWidget(self.view)
 
         # Sidebar (dock)
-        self.palette = PaletteList()
+        self.palette_tabs = PaletteTabWidget(self)
         dock = QDockWidget("Objects", self)
-        dock.setWidget(self.palette)
+        dock.setWidget(self.palette_tabs)
         dock.setAllowedAreas(Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea)
         self.addDockWidget(Qt.LeftDockWidgetArea, dock)
 
@@ -499,14 +607,11 @@ class MainWindow(QMainWindow):
                 h = item.spec.size_h * v
                 item.rect_item.setRect(0, 0, w, h)
                 item.updateLabelLayout()
-                # Snap by center to grid centers
-                center_x = item.pos().x() + w / 2
-                center_y = item.pos().y() + h / 2
-                i = round(center_x / v - 0.5)
-                j = round(center_y / v - 0.5)
-                snapped_center_x = (i + 0.5) * v
-                snapped_center_y = (j + 0.5) * v
-                item.setPos(QPointF(snapped_center_x - w / 2, snapped_center_y - h / 2))
+                top_left = item.pos()
+                snapped_x = round(top_left.x() / v) * v
+                snapped_y = round(top_left.y() / v) * v
+                clamped = self.scene._clamp_top_left(snapped_x, snapped_y, w, h)
+                item.setPos(clamped)
             elif isinstance(item, PreviewObject):
                 item.update_for_cell_size(v)
         self.scene.update()


### PR DESCRIPTION
## Summary
- align placement, movement, and resizing of map objects to cell boundaries so even-sized shapes snap correctly
- add rubber-band selection, shift-click multi-select, and Delete-key removal for placed map objects

## Testing
- python -m compileall gridapp.py

------
https://chatgpt.com/codex/tasks/task_e_68dbdeb8d0a083209d22e6e03eb9089d