### PR TITLE
Enhance palette cloning and snapping safeguards

### DIFF
--- a/gridapp.py
+++ b/gridapp.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import math
 import sys
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Callable, Optional
 
 from PySide6.QtCore import (
     QEvent,
@@ -51,10 +51,16 @@ from PySide6.QtWidgets import (
     QListWidgetItem,
     QMainWindow,
     QMessageBox,
+    QGroupBox,
+    QFormLayout,
     QSpinBox,
     QTabWidget,
     QToolBar,
     QToolButton,
+    QVBoxLayout,
+    QLineEdit,
+    QHBoxLayout,
+    QWidget,
 )
 
 
@@ -84,6 +90,19 @@ DEFAULT_CATEGORIES: dict[str, list[ObjectSpec]] = {
 }
 
 
+def clone_spec(spec: ObjectSpec) -> ObjectSpec:
+    """Create a detached copy of an ``ObjectSpec`` including its color."""
+    return ObjectSpec(spec.name, spec.size_w, spec.size_h, QColor(spec.fill))
+
+
+def contrasting_text_color(color: QColor) -> QColor:
+    if not color.isValid():
+        return QColor(Qt.black)
+    # Perceived brightness using standard luminance coefficients
+    brightness = 0.299 * color.red() + 0.587 * color.green() + 0.114 * color.blue()
+    return QColor(Qt.black if brightness > 186 else Qt.white)
+
+
 # ----------------------------- Map Items -------------------------------
 class MapObject(QGraphicsItemGroup):
     def __init__(self, spec: ObjectSpec, top_left: QPointF, cell_size: int):
@@ -91,14 +110,20 @@ class MapObject(QGraphicsItemGroup):
         self.spec = spec
         self.cell_size = cell_size
 
-        w = spec.size_w * cell_size
-        h = spec.size_h * cell_size
+        # Individual properties copied from spec so each placed object can be
+        # customized without mutating the shared template.
+        self.width_cells = spec.size_w
+        self.height_cells = spec.size_h
+        self.fill_color = QColor(spec.fill)
+
+        w = self.width_cells * cell_size
+        h = self.height_cells * cell_size
         rect_item = QGraphicsRectItem(0, 0, w, h)
-        rect_item.setBrush(QBrush(spec.fill))
+        rect_item.setBrush(QBrush(self.fill_color))
         rect_item.setPen(QPen(Qt.black, 1))
 
         label = QGraphicsSimpleTextItem(spec.name)
-        label.setBrush(Qt.black)
+        label.setBrush(contrasting_text_color(self.fill_color))
         font = QFont()
         font.setPointSizeF(max(8.0, cell_size * 0.5))
         label.setFont(font)
@@ -121,27 +146,30 @@ class MapObject(QGraphicsItemGroup):
         # Ensure above any future overlays; grid is drawn in background
         self.setZValue(1000)
         self.setPos(top_left)
+        self.update_geometry()
 
     def updateLabelLayout(self):
-        w = self.spec.size_w * self.cell_size
-        h = self.spec.size_h * self.cell_size
+        w = self.width_cells * self.cell_size
+        h = self.height_cells * self.cell_size
         label_rect = self.label_item.boundingRect()
         self.label_item.setPos((w - label_rect.width()) / 2, (h - label_rect.height()) / 2)
 
-    def mouseDoubleClickEvent(self, event):
-        # Rename via dialog
-        new_name, ok = QInputDialog.getText(None, "Rename object", "Enter name:", text=self.label_item.text())
-        if ok and new_name.strip():
-            self.label_item.setText(new_name.strip())
-            self.updateLabelLayout()
-        super().mouseDoubleClickEvent(event)
+    def update_geometry(self):
+        self.prepareGeometryChange()
+        w = self.width_cells * self.cell_size
+        h = self.height_cells * self.cell_size
+        self.rect_item.setRect(0, 0, w, h)
+        self.rect_item.setBrush(QBrush(self.fill_color))
+        font = self.label_item.font()
+        font.setPointSizeF(max(8.0, self.cell_size * 0.5))
+        self.label_item.setFont(font)
+        self.label_item.setBrush(contrasting_text_color(self.fill_color))
+        self.updateLabelLayout()
 
-    def mouseReleaseEvent(self, event):
-        super().mouseReleaseEvent(event)
-        # Snap object's CENTER to the nearest cell center on release
+    def snap_to_grid(self):
         cs = self.cell_size
-        w = self.spec.size_w * cs
-        h = self.spec.size_h * cs
+        w = self.width_cells * cs
+        h = self.height_cells * cs
         center_x = self.pos().x() + w / 2
         center_y = self.pos().y() + h / 2
         i = round(center_x / cs - 0.5)
@@ -150,7 +178,79 @@ class MapObject(QGraphicsItemGroup):
         snapped_center_y = (j + 0.5) * cs
         new_x = snapped_center_x - w / 2
         new_y = snapped_center_y - h / 2
+        scene = self.scene()
+        if scene is not None:
+            rect = scene.sceneRect()
+            min_x = rect.left()
+            min_y = rect.top()
+            max_x = rect.left() + max(0.0, rect.width() - w)
+            max_y = rect.top() + max(0.0, rect.height() - h)
+            new_x = max(min_x, min(max_x, new_x))
+            new_y = max(min_y, min(max_y, new_y))
         self.setPos(QPointF(new_x, new_y))
+
+    def mouseDoubleClickEvent(self, event):
+        self.edit_properties()
+        super().mouseDoubleClickEvent(event)
+
+    def mouseReleaseEvent(self, event):
+        super().mouseReleaseEvent(event)
+        scene = self.scene()
+        targets: list[MapObject]
+        if scene is not None:
+            selected = [item for item in scene.selectedItems() if isinstance(item, MapObject)]
+            if len(selected) > 1 and self in selected:
+                targets = selected
+            else:
+                targets = [self]
+        else:
+            targets = [self]
+        for item in targets:
+            item.snap_to_grid()
+
+    def edit_properties(self):
+        parent = None
+        scene = self.scene()
+        if scene is not None and scene.views():
+            parent = scene.views()[0].window()
+
+        new_name, ok = QInputDialog.getText(
+            parent, "Edit object name", "Enter name:", text=self.label_item.text()
+        )
+        if ok and new_name.strip():
+            self.label_item.setText(new_name.strip())
+
+        width, ok = QInputDialog.getInt(
+            parent,
+            "Edit width",
+            "Width (cells):",
+            self.width_cells,
+            1,
+            999,
+        )
+        if ok:
+            self.width_cells = width
+
+        height, ok = QInputDialog.getInt(
+            parent,
+            "Edit height",
+            "Height (cells):",
+            self.height_cells,
+            1,
+            999,
+        )
+        if ok:
+            self.height_cells = height
+
+        color = QColorDialog.getColor(self.fill_color, parent, "Choose color")
+        if color.isValid():
+            self.fill_color = QColor(color)
+
+        self.update_geometry()
+        self.snap_to_grid()
+
+        if parent is not None and hasattr(parent, "refresh_selected_object_properties"):
+            parent.refresh_selected_object_properties(self)
 
 
 class PreviewObject(QGraphicsItemGroup):
@@ -169,6 +269,7 @@ class PreviewObject(QGraphicsItemGroup):
         rect_item.setPen(pen)
 
         label = QGraphicsSimpleTextItem(spec.name)
+        label.setBrush(contrasting_text_color(spec.fill))
         font = QFont()
         font.setPointSizeF(max(8.0, cell_size * 0.5))
         label.setFont(font)
@@ -192,6 +293,7 @@ class PreviewObject(QGraphicsItemGroup):
         font = self.label_item.font()
         font.setPointSizeF(max(8.0, cell_size * 0.5))
         self.label_item.setFont(font)
+        self.label_item.setBrush(contrasting_text_color(self.spec.fill))
         label_rect = self.label_item.boundingRect()
         self.label_item.setPos((w - label_rect.width()) / 2, (h - label_rect.height()) / 2)
 
@@ -392,37 +494,66 @@ class PaletteList(QListWidget):
         self.setAlternatingRowColors(True)
         self.populate()
         self.itemClicked.connect(self._on_item_clicked)
-        self.itemDoubleClicked.connect(self._on_item_double_clicked)
+        self.currentItemChanged.connect(self._on_current_item_changed)
+
+    def _format_spec_label(self, spec: ObjectSpec) -> str:
+        return f"{spec.name}  ({spec.size_w}x{spec.size_h})"
+
+    def _create_item_for_spec(self, spec: ObjectSpec) -> QListWidgetItem:
+        item = QListWidgetItem(self._format_spec_label(spec))
+        item.setData(Qt.UserRole, spec)
+        item.setBackground(QBrush(spec.fill))
+        item.setForeground(QBrush(contrasting_text_color(spec.fill)))
+        return item
+
+    def add_spec(self, spec: ObjectSpec) -> QListWidgetItem:
+        item = self._create_item_for_spec(spec)
+        self.addItem(item)
+        return item
 
     def populate(self):
+        selected_spec: Optional[ObjectSpec] = None
+        current = self.currentItem()
+        if current is not None:
+            selected_spec = current.data(Qt.UserRole)
         self.clear()
+        target_item: Optional[QListWidgetItem] = None
         for spec in self.specs:
-            item = QListWidgetItem(f"{spec.name}  ({spec.size_w}x{spec.size_h})")
-            item.setData(Qt.UserRole, spec)
-            self.addItem(item)
+            item = self.add_spec(spec)
+            if spec is selected_spec:
+                target_item = item
+        if target_item is not None:
+            self.setCurrentItem(target_item)
+
+    def current_spec(self) -> Optional[ObjectSpec]:
+        item = self.currentItem()
+        if item is None:
+            return None
+        return item.data(Qt.UserRole)
+
+    def refresh_item_for_spec(self, spec: ObjectSpec) -> Optional[QListWidgetItem]:
+        for i in range(self.count()):
+            item = self.item(i)
+            if item.data(Qt.UserRole) is spec:
+                item.setText(self._format_spec_label(spec))
+                item.setBackground(QBrush(spec.fill))
+                item.setForeground(QBrush(contrasting_text_color(spec.fill)))
+                item.setData(Qt.UserRole, spec)
+                return item
+        return None
 
     def _on_item_clicked(self, item: QListWidgetItem):
         spec: ObjectSpec = item.data(Qt.UserRole)
         w = self.window()
         if isinstance(w, MainWindow):
             w.activate_placement(spec)
+            w.handle_palette_selection(spec, self)
 
-    def _on_item_double_clicked(self, item: QListWidgetItem):
-        spec: ObjectSpec = item.data(Qt.UserRole)
-        # Edit default text
-        new_name, ok = QInputDialog.getText(self, "Edit default name", "Name:", text=spec.name)
-        if ok and new_name.strip():
-            spec.name = new_name.strip()
-        # Edit color
-        color = QColorDialog.getColor(spec.fill, self, "Choose color")
-        if color.isValid():
-            spec.fill = color
-        # Update list label
-        item.setText(f"{spec.name}  ({spec.size_w}x{spec.size_h})")
-        # If this spec is active, refresh preview
+    def _on_current_item_changed(self, current: Optional[QListWidgetItem], previous):
+        spec = current.data(Qt.UserRole) if current is not None else None
         w = self.window()
         if isinstance(w, MainWindow):
-            w.refresh_active_preview_if(spec)
+            w.handle_palette_selection(spec, self)
 
 
 # ---------------------------- Palette Tabs ----------------------------
@@ -431,11 +562,25 @@ class PaletteTabWidget(QTabWidget):
         super().__init__(parent)
         self.setMovable(True)
         self.tabBarDoubleClicked.connect(self._rename_category)
+        self.currentChanged.connect(self._on_current_tab_changed)
 
-        add_btn = QToolButton(self)
-        add_btn.setText("+")
-        add_btn.clicked.connect(self._prompt_new_category)
-        self.setCornerWidget(add_btn, Qt.TopRightCorner)
+        corner_widget = QWidget(self)
+        layout = QHBoxLayout(corner_widget)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        add_category_btn = QToolButton(corner_widget)
+        add_category_btn.setText("+")
+        add_category_btn.setToolTip("Add category")
+        add_category_btn.clicked.connect(self._prompt_new_category)
+        layout.addWidget(add_category_btn)
+
+        add_object_btn = QToolButton(corner_widget)
+        add_object_btn.setText("+Obj")
+        add_object_btn.setToolTip("Add object to current category")
+        add_object_btn.clicked.connect(self._prompt_new_object)
+        layout.addWidget(add_object_btn)
+
+        self.setCornerWidget(corner_widget, Qt.TopRightCorner)
 
         for name, specs in DEFAULT_CATEGORIES.items():
             self.add_category(name, specs)
@@ -443,6 +588,8 @@ class PaletteTabWidget(QTabWidget):
     def add_category(self, name: str, specs: Optional[list[ObjectSpec]] = None):
         if specs is None:
             specs = []
+        else:
+            specs = [clone_spec(spec) for spec in specs]
         list_widget = PaletteList(specs, self)
         self.addTab(list_widget, name)
         return list_widget
@@ -458,6 +605,28 @@ class PaletteTabWidget(QTabWidget):
             QMessageBox.information(self, "Category exists", f"Category '{name}' already exists.")
             return
         self.add_category(name)
+
+    def _prompt_new_object(self):
+        index = self.currentIndex()
+        if index < 0:
+            return
+        name, ok = QInputDialog.getText(self, "Add Object", "Object name:")
+        if not ok:
+            return
+        name = name.strip()
+        if not name:
+            return
+        width, ok = QInputDialog.getInt(self, "Add Object", "Width (cells):", 1, 1, 999)
+        if not ok:
+            return
+        height, ok = QInputDialog.getInt(self, "Add Object", "Height (cells):", 1, 1, 999)
+        if not ok:
+            return
+        color = QColorDialog.getColor(QColor(Qt.lightGray), self, "Choose color")
+        if not color.isValid():
+            return
+        spec = ObjectSpec(name, width, height, QColor(color))
+        self.add_object_to_index(index, spec)
 
     def _rename_category(self, index: int):
         if index < 0:
@@ -480,6 +649,251 @@ class PaletteTabWidget(QTabWidget):
                 return True
         return False
 
+    def add_object_to_tab(self, name: str, spec: ObjectSpec) -> bool:
+        for i in range(self.count()):
+            if self.tabText(i).lower() == name.lower():
+                return self.add_object_to_index(i, spec)
+        return False
+
+    def add_object_to_index(self, index: int, spec: ObjectSpec) -> bool:
+        if 0 <= index < self.count():
+            widget = self.widget(index)
+            if isinstance(widget, PaletteList):
+                widget.specs.append(spec)
+                item = widget.add_spec(spec)
+                widget.setCurrentItem(item)
+                w = self.window()
+                if isinstance(w, MainWindow):
+                    w.handle_palette_selection(spec, widget)
+                return True
+        return False
+
+    def add_object_to_each_tab(self, prototype: ObjectSpec) -> list[ObjectSpec]:
+        """Add a copy of ``prototype`` to every palette tab.
+
+        Returns the list of newly created ``ObjectSpec`` instances so callers can
+        further customize them if desired.
+        """
+        added: list[ObjectSpec] = []
+        current_index = self.currentIndex()
+        for index in range(self.count()):
+            widget = self.widget(index)
+            if not isinstance(widget, PaletteList):
+                continue
+            spec_copy = clone_spec(prototype)
+            widget.specs.append(spec_copy)
+            widget.add_spec(spec_copy)
+            added.append(spec_copy)
+            if index == current_index:
+                widget.setCurrentItem(widget.item(widget.count() - 1))
+                w = self.window()
+                if isinstance(w, MainWindow):
+                    w.handle_palette_selection(spec_copy, widget)
+        return added
+
+    def _on_current_tab_changed(self, index: int):
+        widget = self.widget(index) if 0 <= index < self.count() else None
+        spec = widget.current_spec() if isinstance(widget, PaletteList) else None
+        w = self.window()
+        if isinstance(w, MainWindow):
+            w.handle_palette_selection(spec, widget if isinstance(widget, PaletteList) else None)
+
+
+# ------------------------- Property Editor Panel -----------------------
+class ObjectPropertyEditor(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(4, 4, 4, 4)
+        layout.setSpacing(8)
+
+        self.default_group = QGroupBox("Default object settings", self)
+        layout.addWidget(self.default_group)
+        default_form = QFormLayout(self.default_group)
+        default_form.setFieldGrowthPolicy(QFormLayout.ExpandingFieldsGrow)
+        self.default_name = QLineEdit(self.default_group)
+        self.default_width = QSpinBox(self.default_group)
+        self.default_height = QSpinBox(self.default_group)
+        self.default_color = QToolButton(self.default_group)
+        self.default_color.setText("Choose…")
+        self.default_width.setRange(1, 999)
+        self.default_height.setRange(1, 999)
+        default_form.addRow("Name", self.default_name)
+        default_form.addRow("Width", self.default_width)
+        default_form.addRow("Height", self.default_height)
+        default_form.addRow("Color", self.default_color)
+
+        self.selected_group = QGroupBox("Selected map object", self)
+        layout.addWidget(self.selected_group)
+        selected_form = QFormLayout(self.selected_group)
+        selected_form.setFieldGrowthPolicy(QFormLayout.ExpandingFieldsGrow)
+        self.selected_name = QLineEdit(self.selected_group)
+        self.selected_width = QSpinBox(self.selected_group)
+        self.selected_height = QSpinBox(self.selected_group)
+        self.selected_color = QToolButton(self.selected_group)
+        self.selected_color.setText("Choose…")
+        self.selected_width.setRange(1, 999)
+        self.selected_height.setRange(1, 999)
+        selected_form.addRow("Name", self.selected_name)
+        selected_form.addRow("Width", self.selected_width)
+        selected_form.addRow("Height", self.selected_height)
+        selected_form.addRow("Color", self.selected_color)
+
+        layout.addStretch(1)
+
+        self._current_spec: Optional[ObjectSpec] = None
+        self._spec_changed: Optional[Callable[[ObjectSpec], None]] = None
+        self._current_object: Optional[MapObject] = None
+        self._block_default = False
+        self._block_selected = False
+
+        self.default_group.setEnabled(False)
+        self.selected_group.setEnabled(False)
+
+        self.default_name.editingFinished.connect(self._commit_default_name)
+        self.default_width.valueChanged.connect(self._commit_default_width)
+        self.default_height.valueChanged.connect(self._commit_default_height)
+        self.default_color.clicked.connect(self._choose_default_color)
+
+        self.selected_name.editingFinished.connect(self._commit_selected_name)
+        self.selected_width.valueChanged.connect(self._commit_selected_width)
+        self.selected_height.valueChanged.connect(self._commit_selected_height)
+        self.selected_color.clicked.connect(self._choose_selected_color)
+
+    def _set_button_color(self, button: QToolButton, color: QColor):
+        if not color.isValid():
+            button.setStyleSheet("")
+            return
+        button.setStyleSheet(
+            "QToolButton {"
+            f"background-color: {color.name()};"
+            "border: 1px solid #444;"
+            "min-width: 48px;"
+            "}"
+        )
+
+    def set_default_spec(self, spec: Optional[ObjectSpec], on_changed: Optional[Callable[[ObjectSpec], None]] = None):
+        self._current_spec = spec
+        self._spec_changed = on_changed
+        if spec is None:
+            self._block_default = True
+            self.default_name.clear()
+            self.default_width.setValue(1)
+            self.default_height.setValue(1)
+            self._set_button_color(self.default_color, QColor())
+            self._block_default = False
+            self.default_group.setEnabled(False)
+            return
+
+        self._block_default = True
+        self.default_name.setText(spec.name)
+        self.default_width.setValue(spec.size_w)
+        self.default_height.setValue(spec.size_h)
+        self._set_button_color(self.default_color, spec.fill)
+        self._block_default = False
+        self.default_group.setEnabled(True)
+
+    def set_selected_object(self, obj: Optional[MapObject]):
+        self._current_object = obj
+        if obj is None:
+            self._block_selected = True
+            self.selected_name.clear()
+            self.selected_width.setValue(1)
+            self.selected_height.setValue(1)
+            self._set_button_color(self.selected_color, QColor())
+            self._block_selected = False
+            self.selected_group.setEnabled(False)
+            return
+
+        self._block_selected = True
+        self.selected_name.setText(obj.label_item.text())
+        self.selected_width.setValue(obj.width_cells)
+        self.selected_height.setValue(obj.height_cells)
+        self._set_button_color(self.selected_color, obj.fill_color)
+        self._block_selected = False
+        self.selected_group.setEnabled(True)
+
+    def refresh_selected_object(self, obj: MapObject):
+        if obj is self._current_object:
+            self.set_selected_object(obj)
+
+    def refresh_default_spec(self, spec: ObjectSpec):
+        if spec is self._current_spec:
+            self.set_default_spec(spec, self._spec_changed)
+
+    def _notify_spec_changed(self):
+        if self._spec_changed is not None and self._current_spec is not None:
+            self._spec_changed(self._current_spec)
+
+    def _commit_default_name(self):
+        if self._block_default or self._current_spec is None:
+            return
+        text = self.default_name.text().strip()
+        if not text:
+            self.default_name.setText(self._current_spec.name)
+            return
+        if text != self._current_spec.name:
+            self._current_spec.name = text
+            self._notify_spec_changed()
+
+    def _commit_default_width(self, value: int):
+        if self._block_default or self._current_spec is None:
+            return
+        if value != self._current_spec.size_w:
+            self._current_spec.size_w = value
+            self._notify_spec_changed()
+
+    def _commit_default_height(self, value: int):
+        if self._block_default or self._current_spec is None:
+            return
+        if value != self._current_spec.size_h:
+            self._current_spec.size_h = value
+            self._notify_spec_changed()
+
+    def _choose_default_color(self):
+        if self._current_spec is None:
+            return
+        color = QColorDialog.getColor(self._current_spec.fill, self, "Choose default color")
+        if color.isValid():
+            self._current_spec.fill = QColor(color)
+            self._set_button_color(self.default_color, self._current_spec.fill)
+            self._notify_spec_changed()
+
+    def _commit_selected_name(self):
+        if self._block_selected or self._current_object is None:
+            return
+        text = self.selected_name.text().strip()
+        if not text:
+            self.selected_name.setText(self._current_object.label_item.text())
+            return
+        if text != self._current_object.label_item.text():
+            self._current_object.label_item.setText(text)
+            self._current_object.updateLabelLayout()
+
+    def _commit_selected_width(self, value: int):
+        if self._block_selected or self._current_object is None:
+            return
+        if value != self._current_object.width_cells:
+            self._current_object.width_cells = value
+            self._current_object.update_geometry()
+            self._current_object.snap_to_grid()
+
+    def _commit_selected_height(self, value: int):
+        if self._block_selected or self._current_object is None:
+            return
+        if value != self._current_object.height_cells:
+            self._current_object.height_cells = value
+            self._current_object.update_geometry()
+            self._current_object.snap_to_grid()
+
+    def _choose_selected_color(self):
+        if self._current_object is None:
+            return
+        color = QColorDialog.getColor(self._current_object.fill_color, self, "Choose object color")
+        if color.isValid():
+            self._current_object.fill_color = QColor(color)
+            self._current_object.update_geometry()
+            self._set_button_color(self.selected_color, self._current_object.fill_color)
 
 # ----------------------------- Main Window -----------------------------
 class MainWindow(QMainWindow):
@@ -495,8 +909,16 @@ class MainWindow(QMainWindow):
 
         # Sidebar (dock)
         self.palette_tabs = PaletteTabWidget(self)
+        self.property_editor = ObjectPropertyEditor(self)
+        sidebar = QWidget(self)
+        sidebar_layout = QVBoxLayout(sidebar)
+        sidebar_layout.setContentsMargins(0, 0, 0, 0)
+        sidebar_layout.setSpacing(6)
+        sidebar_layout.addWidget(self.palette_tabs, 1)
+        sidebar_layout.addWidget(self.property_editor, 0)
+
         dock = QDockWidget("Objects", self)
-        dock.setWidget(self.palette_tabs)
+        dock.setWidget(sidebar)
         dock.setAllowedAreas(Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea)
         self.addDockWidget(Qt.LeftDockWidgetArea, dock)
 
@@ -507,6 +929,7 @@ class MainWindow(QMainWindow):
         self.statusBar().addPermanentWidget(self.hint_label)
         self.view.setMouseTracking(True)
         self.view.viewport().installEventFilter(self)
+        self.scene.selectionChanged.connect(self._on_selection_changed)
 
         # Toolbar actions
         toolbar = QToolBar("Tools", self)
@@ -526,6 +949,10 @@ class MainWindow(QMainWindow):
         self.spin_cell.valueChanged.connect(self.change_cell_size)
         toolbar.addWidget(self.spin_cell)
 
+        first_widget = self.palette_tabs.widget(0)
+        if isinstance(first_widget, PaletteList) and first_widget.count() > 0:
+            first_widget.setCurrentRow(0)
+
     def activate_placement(self, spec: ObjectSpec):
         self.scene.set_active_spec(spec)
         self.hint_label.setText(
@@ -535,6 +962,19 @@ class MainWindow(QMainWindow):
     def refresh_active_preview_if(self, spec: ObjectSpec):
         if self.scene.active_spec is spec:
             self.scene.set_active_spec(spec)  # recreate preview with new name/color
+
+    def handle_palette_selection(self, spec: Optional[ObjectSpec], list_widget: Optional[PaletteList]):
+        if spec is None or list_widget is None:
+            self.property_editor.set_default_spec(None)
+            return
+
+        def on_changed(updated_spec: ObjectSpec):
+            item = list_widget.refresh_item_for_spec(updated_spec)
+            if item is not None:
+                list_widget.setCurrentItem(item)
+            self.refresh_active_preview_if(updated_spec)
+
+        self.property_editor.set_default_spec(spec, on_changed)
 
     def clear_placement_hint(self):
         self.hint_label.setText("")
@@ -557,21 +997,21 @@ class MainWindow(QMainWindow):
         for item in self.scene.items():
             if isinstance(item, MapObject):
                 item.cell_size = v
-                w = item.spec.size_w * v
-                h = item.spec.size_h * v
-                item.rect_item.setRect(0, 0, w, h)
-                item.updateLabelLayout()
-                # Snap by center to grid centers
-                center_x = item.pos().x() + w / 2
-                center_y = item.pos().y() + h / 2
-                i = round(center_x / v - 0.5)
-                j = round(center_y / v - 0.5)
-                snapped_center_x = (i + 0.5) * v
-                snapped_center_y = (j + 0.5) * v
-                item.setPos(QPointF(snapped_center_x - w / 2, snapped_center_y - h / 2))
+                item.update_geometry()
+                item.snap_to_grid()
             elif isinstance(item, PreviewObject):
                 item.update_for_cell_size(v)
         self.scene.update()
+
+    def _on_selection_changed(self):
+        selected = [item for item in self.scene.selectedItems() if isinstance(item, MapObject)]
+        if len(selected) == 1:
+            self.property_editor.set_selected_object(selected[0])
+        else:
+            self.property_editor.set_selected_object(None)
+
+    def refresh_selected_object_properties(self, obj: MapObject):
+        self.property_editor.refresh_selected_object(obj)
 
     def eventFilter(self, watched, event):
         # Show bottom-left-origin coordinates under cursor and drive preview visibility/position


### PR DESCRIPTION
## Summary
- clone palette specs when populating categories and add a helper to duplicate an object across every tab
- clamp dragged objects to the scene while keeping their labels legible with automatic font and contrast updates
- refresh preview widgets to use contrasting label colors when defaults change

## Testing
- python -m compileall gridapp.py

------
https://chatgpt.com/codex/tasks/task_e_68dbe390f2008320bb43a73223a1457e